### PR TITLE
fix: mark_thread_addressed moves to In Review instead of auto-resolving (v2.3.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yocoolab/mcp-server",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yocoolab/mcp-server",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -622,9 +622,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -639,9 +636,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -656,9 +650,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -673,9 +664,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -690,9 +678,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -707,9 +692,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -724,9 +706,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -741,9 +720,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -758,9 +734,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -775,9 +748,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -792,9 +762,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -809,9 +776,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -826,9 +790,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yocoolab/mcp-server",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "MCP server that exposes Yocoolab feedback threads, design selections, and activity events as tools for Claude Code and other MCP-compatible clients.",
   "keywords": [
     "mcp",

--- a/src/__tests__/tools/mark-addressed.test.ts
+++ b/src/__tests__/tools/mark-addressed.test.ts
@@ -7,18 +7,27 @@ function makeApi(): YocoolabApiClient {
     getThread: vi.fn().mockResolvedValue({ id: 'thread-1', repo: 'acme/repo' }),
     updateThread: vi.fn().mockResolvedValue({}),
     addMessage: vi.fn().mockResolvedValue({}),
+    notifyParticipants: vi.fn().mockResolvedValue({ notified: 1 }),
   } as unknown as YocoolabApiClient;
 }
 
 describe('handleMarkAddressed', () => {
-  it('resolves the thread by setting status to resolved', async () => {
+  it('moves the thread to In Review and clears pending — it does NOT resolve', async () => {
     const api = makeApi();
     await handleMarkAddressed(api, { thread_id: 'thread-1' });
 
     expect(api.updateThread).toHaveBeenCalledWith('thread-1', 'acme/repo', {
-      status: 'resolved',
+      kanban_stage: 'in_review',
       claude_code_pending: false,
     });
+  });
+
+  it('never sets status — closing a thread is a human decision', async () => {
+    const api = makeApi();
+    await handleMarkAddressed(api, { thread_id: 'thread-1' });
+
+    const updates = (api.updateThread as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    expect(updates).not.toHaveProperty('status');
   });
 
   it('adds message when provided', async () => {
@@ -35,11 +44,12 @@ describe('handleMarkAddressed', () => {
     expect(api.addMessage).not.toHaveBeenCalled();
   });
 
-  it('returns confirmation text', async () => {
+  it('returns confirmation text saying it moved to In Review, not resolved', async () => {
     const api = makeApi();
     const result = await handleMarkAddressed(api, { thread_id: 'thread-1' });
 
-    expect(result.content[0].text).toContain('Thread thread-1 has been resolved');
+    expect(result.content[0].text).toContain('Thread thread-1 moved to In Review');
+    expect(result.content[0].text).toContain('NOT auto-resolved');
   });
 
   it('includes message in confirmation when provided', async () => {
@@ -47,5 +57,17 @@ describe('handleMarkAddressed', () => {
     const result = await handleMarkAddressed(api, { thread_id: 'thread-1', message: 'Done' });
 
     expect(result.content[0].text).toContain('Message added: "Done"');
+  });
+
+  it('notifies participants that a change is ready for review', async () => {
+    const api = makeApi();
+    await handleMarkAddressed(api, { thread_id: 'thread-1' });
+
+    expect(api.notifyParticipants).toHaveBeenCalledWith(
+      'thread-1',
+      'acme/repo',
+      'pr_created',
+      'A change is ready for your review.',
+    );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,10 +371,10 @@ function startServer(): void {
   
     server.tool(
       'mark_thread_addressed',
-      'Mark a feedback thread as resolved. Optionally add a message explaining how it was addressed.',
+      'Mark a feedback thread as addressed and ready for review. This moves the thread to the "In Review" column and clears the pending flag — it does NOT resolve or close the thread. Only a human closes a thread (after verifying the change). Optionally add a message explaining what you did.',
       {
-        thread_id: z.string().describe('The UUID of the thread to resolve'),
-        message: z.string().optional().describe('Optional message explaining how the feedback was addressed'),
+        thread_id: z.string().describe('The UUID of the thread you have addressed'),
+        message: z.string().optional().describe('Optional message explaining how the feedback was addressed (e.g. a summary of the change and the preview link)'),
       },
       withCompanion(async (args) => {
         return handleMarkAddressed(api, args, emitThreadUpdate);

--- a/src/tools/mark-addressed.ts
+++ b/src/tools/mark-addressed.ts
@@ -27,29 +27,35 @@ export async function handleMarkAddressed(
     await api.addMessage(args.thread_id, finalMessage, thread.repo);
   }
 
-  // Resolve the thread and clear claude_code_pending
+  // Move the thread to the "In Review" column and clear the pending flag — but do
+  // NOT resolve it. Closing a thread is a human decision; the agent's job ends at
+  // "ready for review". The person verifies the change and marks it done. This is
+  // what keeps the user in control of their own board.
   await api.updateThread(args.thread_id, thread.repo, {
-    status: 'resolved',
+    kanban_stage: 'in_review',
     claude_code_pending: false,
   });
 
-  // Notify thread participants
+  // Notify thread participants that a change is ready for their review.
   try {
     const notifyResult = await api.notifyParticipants(
       args.thread_id,
       thread.repo,
-      'resolved',
-      finalMessage || 'Thread resolved by Claude Code',
+      'pr_created',
+      finalMessage || 'A change is ready for your review.',
     );
     console.error(`[mark-addressed] Notified ${notifyResult.notified} participant(s)`);
   } catch (err) {
     console.error('[mark-addressed] Failed to notify participants:', err);
   }
 
-  // Push SSE event to extension (include preview URL)
+  // Push SSE event so the extension flips to the "In review" state (thread stays
+  // open, action buttons stay live). Older extensions that don't know this event
+  // just refetch and read status=open + kanban_stage=in_review.
   if (emitThreadUpdate) {
-    emitThreadUpdate(args.thread_id, 'thread_resolved', {
-      status: 'resolved',
+    emitThreadUpdate(args.thread_id, 'thread_in_review', {
+      status: 'open',
+      kanban_stage: 'in_review',
       message: finalMessage || null,
       preview_url: previewUrl,
     });
@@ -60,7 +66,7 @@ export async function handleMarkAddressed(
       {
         type: 'text' as const,
         text: [
-          `Thread ${args.thread_id} has been resolved.`,
+          `Thread ${args.thread_id} moved to In Review — it is ready for a human to verify and close. It was NOT auto-resolved (only a person closes a thread).`,
           finalMessage ? `Message added: "${finalMessage}"` : '',
           previewUrl ? `Preview: ${previewUrl}` : '',
         ].filter(Boolean).join(' '),


### PR DESCRIPTION
## Why
The agent finishing its work should not close the ticket. Closing a thread is a human decision. Today `mark_thread_addressed` sends `status: 'resolved'`, so the agent auto-closes threads and the user loses control.

## What
`mark_thread_addressed` now:
- moves the thread to the **In Review** column (`kanban_stage: 'in_review'`) and clears `claude_code_pending`
- **leaves `status: 'open'`** — only a human resolves
- notifies participants "A change is ready for your review."
- emits SSE `thread_in_review` (older extensions just refetch and read `status=open` + `kanban_stage`)
- tool description + return text now say "ready for review, not resolved"

Pairs with the backend change (PR attach → In Review, human-resolve → Done) and the extension "In review" state (keeps Ask AI / Build it enabled).

## Publish
After merge: `npm version` is already bumped to **2.3.0**. Run `npm publish` (it will be picked up by the `@2` pin agents use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)