### PR TITLE
fix: messages signed with YOCOOLAB_AGENT_NAME (v2.4.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yocoolab/mcp-server",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yocoolab/mcp-server",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yocoolab/mcp-server",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "MCP server that exposes Yocoolab feedback threads, design selections, and activity events as tools for Claude Code and other MCP-compatible clients.",
   "keywords": [
     "mcp",

--- a/src/__tests__/agent-display-name.test.ts
+++ b/src/__tests__/agent-display-name.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { agentDisplayName } from '../api-client.js';
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe('agentDisplayName', () => {
+  it('falls back to "Claude Code" when YOCOOLAB_AGENT_NAME is unset/empty', () => {
+    vi.stubEnv('YOCOOLAB_AGENT_NAME', '');
+    expect(agentDisplayName()).toBe('Claude Code');
+  });
+
+  it('signs with the configured agent name', () => {
+    vi.stubEnv('YOCOOLAB_AGENT_NAME', 'Hermes Agent');
+    expect(agentDisplayName()).toBe('Hermes Agent');
+  });
+
+  it('trims whitespace-only names to the fallback', () => {
+    vi.stubEnv('YOCOOLAB_AGENT_NAME', '   ');
+    expect(agentDisplayName()).toBe('Claude Code');
+  });
+});

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -106,6 +106,17 @@ export interface DeploymentInfo {
   created_at: string;
 }
 
+/**
+ * The display name this agent signs its thread messages with. Reads
+ * YOCOOLAB_AGENT_NAME at call time (same env the bridge registration uses) so
+ * each agent profile — "Hermes Agent", "Claude Code", "Cursor", … — shows up
+ * under its own name instead of everything being labeled "Claude Code".
+ */
+export function agentDisplayName(): string {
+  const name = (process.env.YOCOOLAB_AGENT_NAME || '').trim();
+  return name || 'Claude Code';
+}
+
 export class YocoolabApiClient {
   private baseUrl: string;
   private token: string;
@@ -172,12 +183,15 @@ export class YocoolabApiClient {
   }
 
   /**
-   * Add a message to a thread.
+   * Add a message to a thread. Messages are signed with the agent's configured
+   * display name (YOCOOLAB_AGENT_NAME) so different agents — Hermes profiles,
+   * Claude Code, Cursor, etc. — are distinguishable in the thread. Falls back
+   * to "Claude Code" for configs that never set a name.
    */
   async addMessage(threadId: string, content: string, repo: string): Promise<MessageDetail> {
     return this.request<MessageDetail>(`/threads/${threadId}/messages`, {
       method: 'POST',
-      body: JSON.stringify({ content, repo, author_display_name: 'Claude Code' }),
+      body: JSON.stringify({ content, repo, author_display_name: agentDisplayName() }),
     });
   }
 
@@ -247,7 +261,7 @@ export class YocoolabApiClient {
   ): Promise<{ notified: number; message: string }> {
     return this.request<{ notified: number; message: string }>(`/threads/${threadId}/notify`, {
       method: 'POST',
-      body: JSON.stringify({ repo, type, content, pr_url: prUrl, author_display_name: 'Claude Code', include_self: true }),
+      body: JSON.stringify({ repo, type, content, pr_url: prUrl, author_display_name: agentDisplayName(), include_self: true }),
     });
   }
 


### PR DESCRIPTION
addMessage/notifyParticipants hardcoded author_display_name: 'Claude Code' — every agent appeared as Claude Code in threads. Now reads YOCOOLAB_AGENT_NAME (same env as bridge registration), falls back to 'Claude Code'. +3 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)